### PR TITLE
Add support for special hours

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import datetime
 import threading
 import src.constants as constants
@@ -7,10 +8,59 @@ from src.schema import Data
 def start_update():
   try:
     print('[{0}] Updating data'.format(datetime.now()))
-    gyms = constants.GYMS_BY_ID
+    gyms = {gym.id: gym for gym in check_for_special_hours()}
     class_details, classes = scraper.scrape_classes(constants.PAGE_LIMIT)
     Data.update_data(gyms=gyms, classes=classes, class_details=class_details, limit=constants.CLASS_HISTORY_LIMIT)
   finally:
     threading.Timer(constants.UPDATE_DELAY, start_update).start()
+
+"""
+Check for special hours and update hours if applicable
+Returns:
+  list of GymType objects with special hours if applicable else uses regular hours
+"""
+def check_for_special_hours():
+  now = datetime.now()
+  current_date = '{0}/{1}'.format(now.month, now.day)
+  try:
+    special_hours = scraper.scrape_special_hours()
+  except:
+    special_hours = None
+
+  # Deep copy so the regular gym times aren't modified
+  gyms = deepcopy(constants.GYMS)
+
+  if special_hours and any(special_hours):
+    for gym in gyms:
+      # Since we have both Teagle Up and Teagle Down
+      if 'Teagle' in gym.name:
+        times = special_hours['Teagle Hall']
+      else:
+        times = special_hours[gym.name]
+      
+      start_index = None
+      for i in range(len(times)):
+        if times[i]['date'] == current_date:
+          start_index = i
+          break
+
+      if not start_index:
+        # No special hours for gym
+        continue
+
+      end_index = min(start_index + 7, len(times))
+      hours = [elt['hours'] for elt in times[start_index:end_index]]
+      # Indices of days given by special hours
+      days_covered = [elt.day for elt in hours]
+
+      # Gym has mix of special and regular hours
+      if len(days_covered) < 7:
+        for reg_hours in gym.times:
+          if reg_hours.day not in days_covered:
+            hours.append(reg_hours)
+
+      gym.times = hours
+
+  return gyms
 
 start_update()

--- a/src/schema.py
+++ b/src/schema.py
@@ -27,8 +27,9 @@ class Data(object):
 
 class DayTimeRangeType(ObjectType):
   day = Int(required=True)
-  start_time = Time(required=True)
   end_time = Time(required=True)
+  special_hours = Boolean(default_value=False, required=True)
+  start_time = Time(required=True)
 
 class GymType(ObjectType):
   id = String(required=True)


### PR DESCRIPTION
My Python is pretty ugly so plz help

- Scrapes special hours from this page https://recreation.athletics.cornell.edu/hours-facilities/cornell-fitness-center-special-hours
- Checks if special hours apply in the next 7 days and updates hours accordingly
- Added `specialHours` field for debugging purposes
- Screenshot below is from querying the hours for Appel. It includes the special hours from 3/1 (today) until 3/3 (when special hours end) and also includes the regular hours for the remaining days
- If a gym is closed for a certain day, the "times" array won't have an entry for that day (Not sure how iOS would handle gyms that are closed for the entire day)

<img width="298" alt="screen shot 2019-03-01 at 4 05 41 pm" src="https://user-images.githubusercontent.com/22579863/53666353-e5f0a080-3c3b-11e9-8d72-336a1d2a54df.png">
