### PR TITLE
Fix ordering of hours

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -59,7 +59,7 @@ def check_for_special_hours():
           if reg_hours.day not in days_covered:
             hours.append(reg_hours)
 
-      gym.times = hours
+      gym.times = sorted(hours, key = lambda hour: hour.day)
 
   return gyms
 


### PR DESCRIPTION
As seen below, iOS uses the index of the hour object to figure out the day rather than the "day" key. Because of this the incorrect hours were shown when using special hours so this fix orders them to the correct way iOS indexes it. This is already deployed so you can check the app. The special hours (since Spring break) are here if you want to check the app's hours https://recreation.athletics.cornell.edu/hours-facilities/cornell-fitness-center-special-hours

<img width="381" alt="Screen Shot 2019-03-28 at 5 50 37 PM" src="https://user-images.githubusercontent.com/22579863/55195992-790def00-5184-11e9-8d2e-287fd2847633.png">

![IMG_1019](https://user-images.githubusercontent.com/22579863/55196151-e3269400-5184-11e9-815c-acda98856b91.png)


