### PR TITLE
Fix special hours scraper by checking dates

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timedelta
 import threading
 import src.constants as constants
 import src.scraper as scraper
@@ -53,7 +53,13 @@ def check_for_special_hours():
                 continue
 
             end_index = min(start_index + 7, len(times))
-            hours = [elt["hours"] for elt in times[start_index:end_index]]
+
+            hours = []
+            for i, time in enumerate(times[start_index:end_index]):
+                new_date = now + timedelta(days=i)
+                if time["date"] == "{0}/{1}".format(new_date.month, new_date.day):
+                    hours.append(time["hours"])
+
             # Indices of days given by special hours
             days_covered = [elt.day for elt in hours]
 


### PR DESCRIPTION
## Overview

<!-- Summarize your changes here. -->
Edited the scraper to check all dates for each special hour. Previously, it only looked for the start date and assumed all dates after were correct. However, Cornell fitness now has multiple special hour schedules on their website so a date might jump from 10/20 to 11/25 as seen below. As a result, we would assume that the hours for 10/21 were actually the special hours for 11/25.
![Screen Shot 2019-10-17 at 3 47 09 PM](https://user-images.githubusercontent.com/22579863/67042390-c8eade00-f0f5-11e9-9e7a-94ad0b58728d.png)

## Changes Made

I added a check for each special hour to make sure the date is correct. For example, it would check if the second special hour is one day after the first special hour.

## Test Coverage

Tested locally and verified by looking at Cornell's fitness special hours page


