### PR TITLE
Add apt-get update to test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         python-version: 3.7
     - name: install and test
       run: |
+        sudo apt-get update
         sudo apt-get install libxml2-dev libxslt-dev
         python -m pip install --upgrade pip
         pip install -r requirements.txt


### PR DESCRIPTION
This fixes the weird 404 that sometimes happens in the `apt-get install` part of this action.

See https://github.com/kq-li/uplift-backend/pull/2 for proof of fix