### PR TITLE
Update github workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,12 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8.10
     - name: install and test
       run: |
         sudo apt-get update
         sudo apt-get install libxml2-dev libxslt-dev
+        sudo apt-get install libpq-dev python-dev
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         python tests.py


### PR DESCRIPTION
Add [sudo apt-get install libpq-dev python-dev] of things to run, and upgrade python-version from 3.7->3.8.10

This is what I did on my local computer to set up the uplift-backend codebase.