### PR TITLE
Fix DST issues

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -51,25 +51,6 @@ enum EquipmentType {
   MISCELLANEOUS
   PLATE_LOADED
 }
-  description: String!
-  gyms: [ClassInstance]
-}
-
-type ClassInstance {
-  id: ID!
-  gymId: Int
-  classId: Int!
-  location: String!
-  instructor: String!
-  isCanceled: Boolean!
-  isVirtual: Boolean!
-  startTime: DateTime
-  endTime: DateTime
-  class_: Class
-  gym: Gym
-}
-
-scalar DateTime
 
 type Facility {
   id: ID!
@@ -102,10 +83,14 @@ type Gym {
 
 type OpenHours {
   id: ID!
-  facilityId: Int!
-  day: Int!
-  startTime: String
-  endTime: String
+  courtType: CourtType
+  endTime: Int!
+  facilityId: Int
+  gymId: Int
+  isShallow: Boolean
+  isSpecial: Boolean!
+  isWomen: Boolean
+  startTime: Int!
 }
 
 type Query {

--- a/src/scrapers/capacities_scraper.py
+++ b/src/scrapers/capacities_scraper.py
@@ -1,7 +1,7 @@
-import pytz, requests
+import requests
 from bs4 import BeautifulSoup
 from collections import namedtuple
-from datetime import datetime, timezone
+from datetime import datetime
 from src.database import db_session
 from src.models.capacity import Capacity
 from src.utils.constants import (
@@ -11,7 +11,6 @@ from src.utils.constants import (
     CAPACITY_MARKER_UPDATED,
     CAPACITY_MARKER_PERCENT,
     CAPACITY_MARKER_PERCENT_NA,
-    EASTERN_TIMEZONE,
 )
 from src.utils.utils import get_facility_id, unix_time
 
@@ -77,20 +76,12 @@ def get_capacity_datetime(time_str):
     """
     Get a datetime object for a Capacity given a time string.
 
-    The time is converted into UTC time from Eastern time.
-
     Parameters:
         - `time_str`    The Eastern time string to parse in `%m/%d/%Y %I:%M %p`
                         format (ex: `12/18/2023 5:54 PM`).
 
-    Returns:    a datetime object in UTC time.
+    Returns:    a datetime object.
     """
     format = "%m/%d/%Y %I:%M %p"
     time_obj = datetime.strptime(time_str, format)
-
-    # Convert from Eastern to Local time
-    eastern_tz = pytz.timezone(EASTERN_TIMEZONE)
-    local_tz = datetime.now(timezone.utc).astimezone().tzinfo
-    time_obj = eastern_tz.localize(time_obj).astimezone(local_tz)
-
     return time_obj

--- a/src/scrapers/scraper_helpers.py
+++ b/src/scrapers/scraper_helpers.py
@@ -1,10 +1,8 @@
-import pytz
 from collections import namedtuple
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from src.database import db_session
 from src.models.openhours import OpenHours
 from src.utils.constants import (
-    EASTERN_TIMEZONE,
     MARKER_ALT,
     MARKER_BADMINTON,
     MARKER_BASKETBALL,
@@ -88,12 +86,6 @@ def get_hours_datetimes(time_str, day):
             time_obj += timedelta(days=1)
 
         result.append(time_obj)
-
-    # Convert from Eastern to Local Time
-    eastern_tz = pytz.timezone(EASTERN_TIMEZONE)
-    local_tz = datetime.now(timezone.utc).astimezone().tzinfo
-    for i in range(len(result)):
-        result[i] = eastern_tz.localize(result[i]).astimezone(local_tz)
 
     return result
 

--- a/src/tests/test_scraper.py
+++ b/src/tests/test_scraper.py
@@ -1,6 +1,5 @@
-import unittest, pytz
-from src.utils.constants import EASTERN_TIMEZONE
-from datetime import datetime, timezone
+import unittest
+from datetime import datetime
 from src.scrapers.scraper_helpers import get_hours_datetimes
 from src.scrapers.capacities_scraper import get_capacity_datetime
 
@@ -23,12 +22,6 @@ class TestScraperHelpers(unittest.TestCase):
         """
         format = "%m/%d/%Y %H:%M"
         date_obj = datetime.strptime(time_str, format)
-
-        # Convert from Eastern to Local Time
-        eastern_tz = pytz.timezone(EASTERN_TIMEZONE)
-        local_tz = datetime.now(timezone.utc).astimezone().tzinfo
-        date_obj = eastern_tz.localize(date_obj).astimezone(local_tz)
-
         return date_obj
 
     def assertDateEqual(self, d1, d2):


### PR DESCRIPTION
## Overview
Fix DST issues.

## Changes Made
- Removed lines of code that converted Eastern time to local time.
  - The reason why we had this in the first place was because the hours in the spreadsheet are in Eastern time. However, this conversion is not necessary since the Docker container is already in Eastern time, so converting the times to local time will cause a shift by one hour due to DST.

## Test Coverage
- Ran the backend locally and pointed the iOS simulator device to use the local endpoint.