### PR TITLE
Revert dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,12 +40,12 @@ itsdangerous==2.0
 jedi==0.18.2
 Jinja2==3.0
 lxml==4.9.2
-Mako==1.2.0
+Mako==1.1.0
 MarkupSafe==2.1.1
 marshmallow==3.0.0rc4
 marshmallow-sqlalchemy==0.16.2
 nodeenv==1.8.0
-pandas==1.3.5
+pandas==2.1.4
 parso==0.8.3
 platformdirs==3.10.0
 pre-commit==1.18.3


### PR DESCRIPTION


## Overview

Solved dev server deployment failure due to versioning errors.


## Changes Made

- Reverted Pandas version to original
- Changed Mako version to 1.1.0 from 1.0.9


## Test Coverage

Tested manually in graphql on local device


## Related PRs or Issues

Related to previous report PR here https://github.com/cuappdev/uplift-backend/pull/165

