### PR TITLE
Changed github workflow file to try migrations 5 times

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -45,6 +45,17 @@ jobs:
             sudo systemctl stop nginx
             sudo systemctl restart nginx
             docker stack deploy -c docker-compose.yml the-stack --with-registry-auth
-            sleep 30s
-            docker exec $(docker ps -q -f name=the-stack_web) flask db upgrade
+            sleep 60s
+            attempt=1
+            max_attempts=5
+            until docker exec $(docker ps -q -f name=the-stack_web) flask db upgrade || [ $attempt -eq $max_attempts ]
+            do
+                echo "Migration attempt $attempt failed. Retrying..."
+                sleep 15
+                attempt=$((attempt + 1))
+            done
+            if [ $attempt -eq $max_attempts ]; then
+                echo "Migration failed after $max_attempts attempts"
+                exit 1
+            fi
             yes | docker system prune -a


### PR DESCRIPTION
## Overview

Changed github workflow to try migrations 5 times

## Changes Made

- Added multiple tries in github workflow to run migrations
- Added longer sleep before running migration
This change was added because the logs show that the migration did not run, most likely because the container has not finished building

## Test Coverage
Locally


## Related PRs or Issues (delete if not applicable)
#169 