### PR TITLE
Removed alembic dependency to previous migrations

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -46,6 +46,8 @@ jobs:
             sudo systemctl restart nginx
             docker stack deploy -c docker-compose.yml the-stack --with-registry-auth
             sleep 60s
+            docker exec $(docker ps -q -f name=the-stack_web) flask db stamp head
+            docker exec $(docker ps -q -f name=the-stack_web) flask db current
             attempt=1
             max_attempts=5
             until docker exec $(docker ps -q -f name=the-stack_web) flask db upgrade || [ $attempt -eq $max_attempts ]


### PR DESCRIPTION
## Overview
Removed alembic dependency on previous migrations based on logs

## Changes Made

- Added line in github workflow to start migration from scratch
This was done because the migration was failing because it could not find an older version of a migration based on logs

## Test Coverage
Locally

## Related PRs or Issues (delete if not applicable)
#169 