### PR TITLE
Changed the condition for running initial scrapes

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,6 +84,7 @@ def shutdown_session(exception=None):
 
 # Only define scheduler tasks if not in migration mode
 if not FLASK_MIGRATE:
+    # Scrape capacities every 15 minutes
     @scheduler.task("interval", id="scrape_hours", seconds=900)
     def scrape_hours():
         try:
@@ -97,6 +98,7 @@ if not FLASK_MIGRATE:
         except Exception as e:
             logging.error(f"Error in scrape_hours: {e}")
 
+    # Scrape capacities every 10 minutes
     @scheduler.task("interval", id="scrape_capacities", seconds=600)
     def scrape_capacities():
         try:
@@ -105,6 +107,7 @@ if not FLASK_MIGRATE:
         except Exception as e:
             logging.error(f"Error in scrape_capacities: {e}")
 
+    # Scrape capacities every hour
     @scheduler.task("interval", id="scrape_classes", seconds=3600)
     def scrape_classes():
         try:

--- a/app.py
+++ b/app.py
@@ -84,7 +84,7 @@ def shutdown_session(exception=None):
 
 # Only define scheduler tasks if not in migration mode
 if not FLASK_MIGRATE:
-    # Scrape capacities every 15 minutes
+    # Scrape hours every 15 minutes
     @scheduler.task("interval", id="scrape_hours", seconds=900)
     def scrape_hours():
         try:
@@ -107,7 +107,7 @@ if not FLASK_MIGRATE:
         except Exception as e:
             logging.error(f"Error in scrape_capacities: {e}")
 
-    # Scrape capacities every hour
+    # Scrape classes every hour
     @scheduler.task("interval", id="scrape_classes", seconds=3600)
     def scrape_classes():
         try:

--- a/app.py
+++ b/app.py
@@ -58,9 +58,16 @@ def should_run_initial_scrape():
     """
     Check if we should run initial scraping:
     - Not in migration mode
-    - Either in production (no WERKZEUG_RUN_MAIN) or in the main Werkzeug process
+    - Only in the main process (Werkzeug or Gunicorn)
     """
-    return not FLASK_MIGRATE and os.environ.get('WERKZEUG_RUN_MAIN') == 'true'
+    # If in migration mode, don't run initial scraping
+    if FLASK_MIGRATE:
+        return False
+    # Check if we're in the main process
+    werkzeug_var = os.environ.get('WERKZEUG_RUN_MAIN')
+    # Logic: if in local, then werkzeug_var exists: so only run when true to prevent double running
+    # If in Gunicorn, then werkzeug_var is None, so then it will also run
+    return werkzeug_var is None or werkzeug_var == 'true'
 
 # Initialize scheduler only if not in migration mode
 if not FLASK_MIGRATE:

--- a/app.py
+++ b/app.py
@@ -60,15 +60,7 @@ def should_run_initial_scrape():
     - Not in migration mode
     - Either in production (no WERKZEUG_RUN_MAIN) or in the main Werkzeug process
     """
-    is_development = app.debug
-    if is_development:
-        # In development, only run in main Werkzeug process
-        is_main_process = os.environ.get('WERKZEUG_RUN_MAIN') == 'true'
-    else:
-        # In production (Gunicorn), always consider it main process
-        is_main_process = True
-
-    return not FLASK_MIGRATE and is_main_process
+    return not FLASK_MIGRATE and os.environ.get('WERKZEUG_RUN_MAIN') == 'true'
 
 # Initialize scheduler only if not in migration mode
 if not FLASK_MIGRATE:


### PR DESCRIPTION
## Overview
Edited the condition for running the initial scrape

## Changes Made
Changed the run condition:
- If in migration mode, then do not run scrapers
- If in local running with WERKZEUG, then only run scrapers if env variable WERKZEUG_RUN_MAIN is true (this prevents double running/auto-reload, causing the scrapers to run twice resulting in timeouts)
- If in development/production server with Gunicorn, run the scrapers

This change was added because in local, when I prevented the auto-reload, it would stop running the scrapers in the dev server. Hence, with this more careful condition check, we can satisfy both running it once in local, but still run them fine in the dev server.

## Test Coverage
locally

## Related PRs or Issues (delete if not applicable)
#169 