### PR TITLE
topic subscription logic for notifs

### DIFF
--- a/src/schema.py
+++ b/src/schema.py
@@ -918,7 +918,9 @@ class EditCapacityReminder(graphene.Mutation):
 
         for topic in topics:
             try:
-                messaging.unsubscribe_from_topic(reminder.fcm_token, topic)
+                response = messaging.unsubscribe_from_topic(reminder.fcm_token, topic)
+                if response.success_count == 0:
+                        raise Exception(response.errors[0].reason)
             except Exception as error:
                 raise GraphQLError(f"Error subscribing to topic: {error}")
 
@@ -927,7 +929,9 @@ class EditCapacityReminder(graphene.Mutation):
 
         for topic in topics:
             try:
-                messaging.subscribe_to_topic(reminder.fcm_token, topic)
+                response = messaging.subscribe_to_topic(reminder.fcm_token, topic)
+                if response.success_count == 0:
+                        raise Exception(response.errors[0].reason)
             except Exception as error:
                 raise GraphQLError(f"Error subscribing to topic: {error}")
 
@@ -956,7 +960,9 @@ class DeleteCapacityReminder(graphene.Mutation):
 
         for topic in topics:
             try:
-                messaging.unsubscribe_from_topic(reminder.fcm_token, topic)
+                response = messaging.unsubscribe_from_topic(reminder.fcm_token, topic)
+                if response.success_count == 0:
+                        raise Exception(response.errors[0].reason)
             except Exception as error:
                 raise GraphQLError(f"Error unsubscribing from topic {topic}: {error}")
 


### PR DESCRIPTION
fix topic subscription logic

previously we call `messaging.subscribe_to_topic(fcm_token, topic_name)` to subscribe, and catch error if firebase fails to subscribe. however, if a subscription fails, firebase_admin does not throw an exception. it just returns an object with success_count == 0, which we previously did not check for. 

this pr adds that logic to ensure graphQL mutation is only successful if topic subscription is successful. 